### PR TITLE
set metric interval to 60s

### DIFF
--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -69,6 +69,7 @@ service:
     metrics:
       readers:
         - periodic:
+            interval: 60000
             exporter:
               otlp:
                 protocol: http/protobuf


### PR DESCRIPTION
デフォルトは10sだがMackerelでのメトリック粒度は60sなので無駄打ちを減らす。
intervalはmsのint指定なので60 * 1000